### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Nuxt module that implements AI Engine Optimization (AEO) using Schema.org JSON
 </p>
 
 <p>
-  <a href="/CHANGELOG.md">✨ Release Notes</a>
+  <a href="https://github.com/yeonjulee1005/nuxt-aeo/releases">✨ Release Notes</a>
   <!-- | <a href="https://stackblitz.com/github/your-org/nuxt-aeo?file=playground%2Fapp.vue">🏀 Online playground</a> -->
   | <a href="/docs">📖 Documentation</a>
 </p>
@@ -37,7 +37,7 @@ This module uses Schema.org JSON-LD format to add structured data to web pages a
 Install the module in your Nuxt application:
 
 ```bash
-npx nuxi module add nuxt-aeo
+bun add nuxt-aeo
 ```
 
 Once installed, you can start using Nuxt AEO ✨

--- a/docs/components/content/example-article-schema.vue
+++ b/docs/components/content/example-article-schema.vue
@@ -123,4 +123,3 @@ withDefaults(defineProps<Props>(), {
   margin-right: 0.5rem;
 }
 </style>
-

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -5,7 +5,7 @@ export default defineNuxtConfig({
     '@nuxt/content',
     '@nuxtjs/mdc',
     'nuxt-studio',
-    '../src/module',
+    'nuxt-aeo',
     '@nuxt/devtools',
     '@vueuse/nuxt',
   ],

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,7 @@
     "@nuxtjs/mdc": "^0.19.1",
     "better-sqlite3": "^12.5.0",
     "nuxt": "^4.2.2",
+    "nuxt-aeo": "latest",
     "nuxt-studio": "^1.0.0-beta.1"
   },
   "devDependencies": {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,4 +17,13 @@ export default createConfigForNuxt({
 })
   .append(
     // your custom flat config here...
+    {
+      files: ['docs/**/*.vue', 'playground/**/*.vue'],
+      rules: {
+        // Nuxt layouts and pages use file names as component names
+        'vue/multi-word-component-names': 'off',
+        // v-html is used for rendering article content
+        'vue/no-v-html': 'warn',
+      },
+    },
   )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-aeo",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Nuxt module for AI Engine Optimization (AEO) using Schema.org JSON-LD structured data",
   "keywords": [
     "nuxt",

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,5 +1,5 @@
 export default defineNuxtConfig({
-  modules: ['../src/module'],
+  modules: ['nuxt-aeo'],
   devtools: { enabled: true },
   /**
    * AEO (AI Engine Optimization) module configuration

--- a/playground/package.json
+++ b/playground/package.json
@@ -8,6 +8,7 @@
     "generate": "nuxi generate"
   },
   "dependencies": {
-    "nuxt": "^4.2.2"
+    "nuxt": "^4.2.2",
+    "nuxt-aeo": "latest"
   }
 }

--- a/playground/pages/article.vue
+++ b/playground/pages/article.vue
@@ -48,7 +48,9 @@
           {{ article.description }}
         </p>
 
-        <div v-html="article.articleBody" />
+        <div>
+          {{ article.articleBody }}
+        </div>
       </div>
 
       <footer class="article-footer">

--- a/playground/pages/person.vue
+++ b/playground/pages/person.vue
@@ -10,32 +10,57 @@
         >
         <div class="profile-info">
           <h1>{{ person.name }}</h1>
-          <p v-if="person.alternateName" class="alternate-name">
+          <p
+            v-if="person.alternateName"
+            class="alternate-name"
+          >
             {{ person.alternateName }}
           </p>
-          <p v-if="person.jobTitle" class="job-title">
+          <p
+            v-if="person.jobTitle"
+            class="job-title"
+          >
             {{ person.jobTitle }}
           </p>
-          <p v-if="person.description" class="description">
+          <p
+            v-if="person.description"
+            class="description"
+          >
             {{ person.description }}
           </p>
         </div>
       </div>
 
-      <div v-if="person.knowsAbout && person.knowsAbout.length > 0" class="skills-section">
+      <div
+        v-if="person.knowsAbout && person.knowsAbout.length > 0"
+        class="skills-section"
+      >
         <h2>Technical Stack</h2>
         <ul class="skills-list">
-          <li v-for="(skill, index) in person.knowsAbout" :key="index">
+          <li
+            v-for="(skill, index) in person.knowsAbout"
+            :key="index"
+          >
             {{ skill }}
           </li>
         </ul>
       </div>
 
-      <div v-if="person.sameAs && person.sameAs.length > 0" class="social-section">
+      <div
+        v-if="person.sameAs && person.sameAs.length > 0"
+        class="social-section"
+      >
         <h2>Social Media</h2>
         <ul class="social-list">
-          <li v-for="(url, index) in person.sameAs" :key="index">
-            <a :href="url" target="_blank" rel="noopener noreferrer">{{ url }}</a>
+          <li
+            v-for="(url, index) in person.sameAs"
+            :key="index"
+          >
+            <a
+              :href="url"
+              target="_blank"
+              rel="noopener noreferrer"
+            >{{ url }}</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
v.1.2.2
fix(eslint): disable multi-word-component-names for Nuxt layouts and pages

- Disable vue/multi-word-component-names rule for docs and playground directories
- Nuxt layouts and pages use file names as component names (default, docs, index, [...slug])
- Change vue/no-v-html to warning instead of error for playground examples