### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ A Nuxt module that implements AI Engine Optimization (AEO) using Schema.org JSON
 
 <p>
   <a href="https://github.com/yeonjulee1005/nuxt-aeo/releases">✨ Release Notes</a>
-  <!-- | <a href="https://stackblitz.com/github/your-org/nuxt-aeo?file=playground%2Fapp.vue">🏀 Online playground</a> -->
-  | <a href="/docs">📖 Documentation</a>
+  | <a href="https://nuxt-aeo-playground.vercel.app">🏀 Online playground</a>
+  | <a href="https://nuxt-aeo-docs.vercel.app">📖 Documentation</a>
 </p>
 
 <br>

--- a/docs/app.vue
+++ b/docs/app.vue
@@ -33,6 +33,12 @@ const navItems = computed<NavigationMenuItem[]>(() => [
     to: '/examples/organization',
     active: route.path.startsWith('/examples'),
   },
+  {
+    label: 'Playground',
+    icon: 'i-lucide-play',
+    to: 'https://nuxt-aeo-playground.vercel.app',
+    target: '_blank',
+  },
 ])
 </script>
 

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -1,5 +1,4 @@
 export default defineNuxtConfig({
-  // Add local nuxt-aeo module
   modules: [
     '@nuxt/ui',
     '@nuxt/content',
@@ -11,6 +10,7 @@ export default defineNuxtConfig({
   ],
 
   devtools: { enabled: true },
+
   css: ['~/assets/css/main.css'],
 
   colorMode: {
@@ -26,6 +26,14 @@ export default defineNuxtConfig({
           searchDepth: 3,
         },
       },
+    },
+  },
+
+  // Static site generation for Vercel
+  nitro: {
+    prerender: {
+      crawlLinks: true,
+      routes: ['/'],
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-aeo",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Nuxt module for AI Engine Optimization (AEO) using Schema.org JSON-LD structured data",
   "keywords": [
     "nuxt",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,6 @@
     "dist",
     "node_modules",
     "playground",
+    "docs"
   ]
 }


### PR DESCRIPTION
v1.2.3
docs: Add playground link to navigation and improve Vercel deployment

- Add Playground link to navigation menu in app.vue
- Configure static site generation with nitro.prerender for Vercel
- Exclude docs directory from root TypeScript type checking