### PR TITLE
v1.2.3

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -14,7 +14,7 @@ export default defineNuxtConfig({
   css: ['~/assets/css/main.css'],
 
   colorMode: {
-    preference: 'light',
+    preference: 'dark',
   },
 
   // Nuxt Content configuration
@@ -34,6 +34,10 @@ export default defineNuxtConfig({
     prerender: {
       crawlLinks: true,
       routes: ['/'],
+      failOnError: false,
+    },
+    output: {
+      publicDir: '.output/public',
     },
   },
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,17 +7,20 @@
     "build": "nuxi build",
     "generate": "nuxi generate",
     "preview": "nuxi preview",
-    "cleanup": "rm -rf .nuxt .output .data node_modules/.cache"
+    "cleanup": "rm -rf .nuxt .output .data node_modules/.cache",
+    "vercel-build": "npm run build"
   },
   "dependencies": {
     "@nuxt/content": "^3.0.0",
     "@nuxt/devtools": "^3.1.1",
     "@nuxt/ui": "^4.3.0",
     "@nuxtjs/mdc": "^0.19.1",
-    "better-sqlite3": "^12.5.0",
     "nuxt": "^4.2.2",
     "nuxt-aeo": "latest",
     "nuxt-studio": "^1.0.0-beta.1"
+  },
+  "optionalDependencies": {
+    "better-sqlite3": "^12.5.0"
   },
   "devDependencies": {
     "@iconify-json/simple-icons": "^1.2.63",

--- a/docs/pages/[...slug].vue
+++ b/docs/pages/[...slug].vue
@@ -3,6 +3,8 @@ import type { ContentNavigationItem } from '@nuxt/content'
 
 definePageMeta({
   layout: 'docs',
+  // Exclude Nuxt internal paths
+  alias: [],
 })
 
 const route = useRoute()
@@ -27,6 +29,16 @@ function mapContentNavigation(navigation: ContentNavigationItem[] | null | undef
 }
 
 const { data: page } = await useAsyncData(`docs-${route.path}`, async () => {
+  // Skip if it's a Nuxt internal path or API route
+  if (
+    route.path.startsWith('/_nuxt/')
+    || route.path.startsWith('/__nuxt')
+    || route.path.startsWith('/api/')
+    || route.path.startsWith('/_')
+  ) {
+    return null
+  }
+
   // Normalize path: remove trailing slash
   const path = route.path.endsWith('/') ? route.path.slice(0, -1) : route.path
 
@@ -39,6 +51,8 @@ const { data: page } = await useAsyncData(`docs-${route.path}`, async () => {
   }
 
   return result
+}, {
+  default: () => null,
 })
 
 if (!page.value) {


### PR DESCRIPTION
docs: Add playground link to navigation and improve Vercel deployment

- Add Playground link to navigation menu in app.vue
- Configure static site generation with nitro.prerender for Vercel
- Exclude docs directory from root TypeScript type checking