### PR TITLE
v1.2.3

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -36,9 +36,6 @@ export default defineNuxtConfig({
       routes: ['/'],
       failOnError: false,
     },
-    output: {
-      publicDir: '.output/public',
-    },
   },
 
   // AEO module configuration

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,20 +7,17 @@
     "build": "nuxi build",
     "generate": "nuxi generate",
     "preview": "nuxi preview",
-    "cleanup": "rm -rf .nuxt .output .data node_modules/.cache",
-    "vercel-build": "npm run build"
+    "cleanup": "rm -rf .nuxt .output .data node_modules/.cache"
   },
   "dependencies": {
     "@nuxt/content": "^3.0.0",
     "@nuxt/devtools": "^3.1.1",
     "@nuxt/ui": "^4.3.0",
     "@nuxtjs/mdc": "^0.19.1",
+    "better-sqlite3": "^12.5.0",
     "nuxt": "^4.2.2",
     "nuxt-aeo": "latest",
     "nuxt-studio": "^1.0.0-beta.1"
-  },
-  "optionalDependencies": {
-    "better-sqlite3": "^12.5.0"
   },
   "devDependencies": {
     "@iconify-json/simple-icons": "^1.2.63",


### PR DESCRIPTION
docs: Add playground link to navigation and improve Vercel deployment

- Add Playground link to navigation menu in app.vue
- Configure static site generation with nitro.prerender for Vercel
- Exclude docs directory from root TypeScript type checking