### PR TITLE
v1.2.3

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -29,8 +29,15 @@ export default defineNuxtConfig({
     },
   },
 
+  // Route rules for static site generation
+  routeRules: {
+    // Prerender all pages at build time
+    '/**': { prerender: true },
+  },
+
   // Static site generation for Vercel
   nitro: {
+    preset: 'static',
     prerender: {
       crawlLinks: true,
       routes: ['/'],

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,8 @@
     "build": "nuxi build",
     "generate": "nuxi generate",
     "preview": "nuxi preview",
-    "cleanup": "rm -rf .nuxt .output .data node_modules/.cache"
+    "cleanup": "rm -rf .nuxt .output .data node_modules/.cache",
+    "vercel-build": "nuxi generate"
   },
   "dependencies": {
     "@nuxt/content": "^3.0.0",


### PR DESCRIPTION
docs: Add playground link to navigation and improve Vercel deployment

- Add Playground link to navigation menu in app.vue
- Configure static site generation with nitro.prerender for Vercel
- Exclude docs directory from root TypeScript type checking