### PR TITLE
Development

### DIFF
--- a/IMPLEMENTATION_HISTORY.md
+++ b/IMPLEMENTATION_HISTORY.md
@@ -1,0 +1,329 @@
+# Nuxt AEO 모듈 구현 히스토리
+
+## 1. 기본 구조 설계
+
+### 모듈 진입점 (`src/module.ts`)
+
+Nuxt 모듈의 기본 구조를 설계했습니다:
+
+```typescript
+export default defineNuxtModule<ModuleOptions>({
+  meta: {
+    name: 'nuxt-aeo',
+    configKey: 'aeo',
+  },
+  setup(options, nuxt) {
+    // 모듈 옵션을 runtime config에 추가
+    // 플러그인 등록
+    // composable 자동 import 설정
+  },
+})
+```
+
+**핵심 설계 결정:**
+- `configKey: 'aeo'`로 설정하여 `nuxt.config.ts`에서 `aeo` 옵션으로 접근 가능
+- `runtimeConfig.public`에 옵션을 저장하여 클라이언트/서버 양쪽에서 접근 가능
+- `addImportsDir`로 composable 자동 import 구현
+
+---
+
+## 2. 범용 Schema Composable 구현 (`useSchema`)
+
+### 2.1 초기 구현: JSON-LD 생성
+
+가장 먼저 Schema.org JSON-LD를 생성하는 기본 기능을 구현했습니다:
+
+```typescript
+export function useSchema(schema: Record<string, unknown>) {
+  // JSON-LD를 <head>에 주입
+  useHead({
+    script: [{
+      type: 'application/ld+json',
+      innerHTML: JSON.stringify(schema, null, 2),
+    }],
+  })
+}
+```
+
+### 2.2 키 변환 로직 추가
+
+사용자 편의성을 위해 `context`와 `type`을 `@context`와 `@type`으로 자동 변환하는 기능을 추가했습니다:
+
+```typescript
+function transformSchemaKeys(obj: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  
+  for (const [key, value] of Object.entries(obj)) {
+    // context → @context, type → @type 변환
+    const transformedKey = key === 'context' ? '@context' : key === 'type' ? '@type' : key
+    
+    // 중첩 객체와 배열도 재귀적으로 변환
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      result[transformedKey] = transformSchemaKeys(value as Record<string, unknown>)
+    } else if (Array.isArray(value)) {
+      result[transformedKey] = value.map(item => 
+        item && typeof item === 'object' 
+          ? transformSchemaKeys(item as Record<string, unknown>)
+          : item
+      )
+    } else {
+      result[transformedKey] = value
+    }
+  }
+  
+  return result
+}
+```
+
+**왜 이렇게 구현했나요?**
+- JavaScript 객체에서 `@`로 시작하는 키는 따옴표 없이 사용하기 어려움
+- `context`, `type`을 일반 속성처럼 사용할 수 있게 하여 개발자 경험 개선
+- 중첩된 객체와 배열도 자동 변환하여 모든 Schema 구조 지원
+
+### 2.3 시멘틱 HTML 자동 생성 기능 추가
+
+AI 모델의 학습을 최적화하기 위해 시멘틱 HTML 자동 생성 기능을 추가했습니다:
+
+```typescript
+// Schema 타입별 HTML 생성 함수
+function generateSemanticHTML(schemaType: string, schemaData: Record<string, unknown>): string | null {
+  const type = schemaType.toLowerCase()
+  
+  switch (type) {
+    case 'organization':
+      return generateOrganizationHTML(schemaData)
+    case 'person':
+      return generatePersonHTML(schemaData)
+    case 'itemlist':
+      return generateItemListHTML(schemaData)
+    default:
+      return generateGenericHTML(schemaType, schemaData)
+  }
+}
+```
+
+**구현 세부사항:**
+- `itemscope`, `itemtype`, `itemprop` 속성을 사용한 마이크로데이터 형식
+- HTML 이스케이프 처리로 XSS 방지
+- `visually-hidden` CSS 클래스로 사용자에게는 보이지 않지만 크롤러는 읽을 수 있도록 처리
+
+### 2.4 클라이언트 사이드 HTML 주입
+
+시멘틱 HTML을 클라이언트 사이드에서 동적으로 주입하는 로직을 구현했습니다:
+
+```typescript
+if (import.meta.client) {
+  const injectSemanticHTML = () => {
+    // 기존 HTML 제거 (같은 타입이 중복 주입되는 것 방지)
+    const existing = document.querySelector(`.nuxt-aeo-semantic-${schemaType.toLowerCase()}`)
+    if (existing) existing.remove()
+    
+    // 새로운 시멘틱 HTML 주입
+    const semanticDiv = document.createElement('div')
+    semanticDiv.className = `nuxt-aeo-semantic-${schemaType.toLowerCase()} ${visuallyHidden ? 'nuxt-aeo-visually-hidden' : ''}`
+    semanticDiv.setAttribute('aria-hidden', 'true')
+    semanticDiv.innerHTML = semanticHtml
+    document.body.appendChild(semanticDiv)
+  }
+  
+  // DOM 준비 상태에 따라 실행
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', injectSemanticHTML)
+  } else {
+    injectSemanticHTML()
+  }
+}
+```
+
+---
+
+## 3. FAQPage 전용 Composable 구현 (`useSchemaPage`)
+
+### 3.1 초기 설계
+
+FAQPage는 가장 많이 사용되는 Schema 타입 중 하나였기 때문에, 전용 composable을 만들기로 결정했습니다:
+
+```typescript
+export function useSchemaPage(data: {
+  mainEntity: Array<{
+    name: string
+    acceptedAnswer: { text: string }
+  }>
+}) {
+  // useSchema를 내부적으로 사용
+  useSchema({
+    context: 'https://schema.org',
+    type: 'FAQPage',
+    mainEntity: data.mainEntity.map(questionInput => ({
+      type: 'Question',
+      name: questionInput.name,
+      acceptedAnswer: {
+        type: 'Answer',
+        text: questionInput.acceptedAnswer.text,
+      },
+    })),
+  })
+}
+```
+
+**설계 이유:**
+- FAQPage는 구조가 복잡하여 직접 작성하기 어려움
+- `name`, `acceptedAnswer.text`만 제공하면 나머지는 자동 변환
+- 타입 안전성 보장
+
+### 3.2 시멘틱 HTML 생성 추가
+
+FAQPage 전용 시멘틱 HTML 생성 함수를 구현했습니다:
+
+```typescript
+function generateFAQPageSemanticHTML(mainEntity: Array<{
+  name: string
+  acceptedAnswer: { text: string }
+}>): string {
+  const questionsHtml = mainEntity
+    .map((question) => {
+      const questionText = escapeHtml(question.name || '')
+      const answerText = escapeHtml(question.acceptedAnswer.text || '')
+      
+      return `
+        <div itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+          <h2 itemprop="name">${questionText}</h2>
+          <div itemprop="acceptedAnswer" itemscope itemtype="https://schema.org/Answer">
+            <p itemprop="text">${answerText}</p>
+          </div>
+        </div>
+      `.trim()
+    })
+    .join('\n')
+  
+  return `
+    <div itemscope itemtype="https://schema.org/FAQPage">
+      ${questionsHtml}
+    </div>
+  `.trim()
+}
+```
+
+**기본값 설정:**
+- `renderHtml: true` (기본값) - FAQPage는 시멘틱 HTML이 중요
+- `visuallyHidden: true` (기본값) - 사용자 경험 유지
+
+---
+
+## 4. 전역 스키마 자동 주입 (`plugin.ts`)
+
+### 4.1 플러그인 구현
+
+모든 페이지에 전역 스키마를 자동으로 주입하는 플러그인을 구현했습니다:
+
+```typescript
+export default defineNuxtPlugin(() => {
+  const config = useRuntimeConfig()
+  const aeoConfig = config.public.aeo as ModuleOptions
+  
+  // autoInject가 false면 주입하지 않음
+  if (aeoConfig?.autoInject === false) {
+    return
+  }
+  
+  // schemas 배열이 있으면 각각 주입
+  if (aeoConfig?.schemas && aeoConfig.schemas.length > 0) {
+    for (const schema of aeoConfig.schemas) {
+      useSchema({
+        context: 'https://schema.org',
+        ...schemaData,
+        renderHtml,
+        visuallyHidden,
+      })
+    }
+  } else {
+    // schemas가 없으면 기본 Project Schema 주입
+    useSchema({
+      context: 'https://schema.org',
+      type: 'Project',
+    })
+  }
+})
+```
+
+**설계 결정:**
+- 플러그인은 모든 페이지에서 자동 실행
+- `autoInject: false` 옵션으로 전역 주입 비활성화 가능
+- 개별 스키마의 `renderHtml`, `visuallyHidden` 옵션이 전역 옵션보다 우선
+
+---
+
+## 5. 타입 안전성 보장
+
+### 5.1 TypeScript 타입 정의
+
+모든 Schema 타입에 대한 TypeScript 타입을 정의했습니다:
+
+```typescript
+export interface ModuleOptions {
+  schemas?: GlobalSchema[]
+  autoInject?: boolean
+  renderHtml?: boolean
+  visuallyHidden?: boolean
+}
+
+export type GlobalSchema = {
+  context?: 'https://schema.org' | string
+  type: string
+  renderHtml?: boolean
+  visuallyHidden?: boolean
+  [key: string]: unknown
+}
+```
+
+### 5.2 Nuxt Config 타입 확장
+
+`nuxt.config.ts`에서 타입 체크가 가능하도록 타입을 확장했습니다:
+
+```typescript
+declare module '@nuxt/schema' {
+  interface NuxtConfig {
+    aeo?: ModuleOptions
+  }
+}
+```
+
+---
+
+## 6. 주요 구현 결정사항 요약
+
+### 6.1 왜 `useHead()`를 사용했나요?
+
+- Nuxt의 SSR 환경에서 `<head>` 태그에 안전하게 주입 가능
+- 클라이언트와 서버 양쪽에서 동작
+- Nuxt의 내장 기능을 활용하여 안정성 보장
+
+### 6.2 왜 시멘틱 HTML을 클라이언트에서 주입하나요?
+
+- SSR에서는 `<body>`에 직접 주입하기 어려움
+- `useHead()`는 `<head>`에만 주입 가능
+- 클라이언트에서 주입하면 DOM 조작이 자유로움
+- `aria-hidden="true"`로 스크린 리더에 노출되지 않도록 처리
+
+### 6.3 왜 `visually-hidden` 클래스를 사용하나요?
+
+- `display: none`은 일부 크롤러가 읽지 않을 수 있음
+- `visually-hidden`은 화면에는 보이지 않지만 DOM에는 존재
+- LLM 크롤러와 검색 엔진이 읽을 수 있음
+- 접근성 유지 (스크린 리더는 읽지 않음)
+
+### 6.4 왜 `context`, `type`을 자동 변환하나요?
+
+- JavaScript 객체에서 `@`로 시작하는 키는 사용하기 불편
+- `context: 'https://schema.org'`처럼 일반 속성처럼 사용 가능
+- 중첩 객체와 배열도 재귀적으로 변환하여 모든 Schema 구조 지원
+
+---
+
+## 7. 향후 개선 계획
+
+1. **더 많은 Schema 타입 지원**: Article, TechArticle, NewsArticle 등
+2. **성능 최적화**: 시멘틱 HTML 생성 로직 최적화
+3. **타입 안전성 강화**: 더 엄격한 타입 체크
+4. **테스트 코드 추가**: 단위 테스트 및 통합 테스트
+

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ export default defineNuxtConfig({
 - 🔧 **Flexible Configuration**: Configure global schemas or add individual schemas per page
 - 📚 **Various Schema Support**: Supports all Schema.org types including Person, Organization, FAQPage, ItemList, Article, etc.
 - ✨ **Easy to Use**: Using `context` and `type` automatically converts them to `@context` and `@type` internally, so you can use them without quotes
+- 🔗 **Automatic URL Normalization**: Automatically normalizes relative URLs to absolute URLs in `url`, `image`, `logo`, and `item` properties, ensuring consistent URL formatting for AI models and search engines
 - 🎨 **Automatic Semantic HTML Generation**: Automatically generates semantic HTML based on schema data to optimize LLM crawling. Controllable at both global and individual schema levels
 - 👁️ **Visual Hiding**: Generated semantic HTML is hidden with the `visually-hidden` class, allowing crawlers to read it without affecting user experience
 
@@ -120,7 +121,7 @@ Add question-answer structures to FAQ pages. Semantic HTML is also automatically
 
 ```vue
 <script setup lang="ts">
-useSchemaPage({
+useSchemaFaq({
   mainEntity: [
     {
       name: 'What is the Nuxt AEO module?',
@@ -148,6 +149,12 @@ useSchemaPage({
 - Generated HTML is not visible to users but is included in the HTML source for LLMs and crawlers to read
 - Using JSON-LD together with semantic HTML improves AI model content understanding
 
+**URL Normalization:**
+- `useSchemaFaq()` automatically normalizes all `url`, `image`, `logo`, and `item` properties to absolute URLs
+- Relative URLs are combined with the base URL (from `useRequestURL()` or `app.baseURL`)
+- Absolute URLs (starting with `http://` or `https://`) remain unchanged
+- This ensures consistent URL formatting for AI models and search engines
+
 ### Universal useSchema Function
 
 You can also create Schema objects directly. Using `context` and `type` automatically converts them to `@context` and `@type` internally:
@@ -160,7 +167,7 @@ useSchema({
   type: 'Organization',
   name: 'Example Company',
   url: 'https://example.com',
-  logo: 'https://example.com/logo.png',
+  logo: '/logo.png', // Relative URL from /public folder - automatically normalized to absolute URL
   // renderHtml: true (default) - Automatic semantic HTML generation
   // visuallyHidden: true (default) - Visually hide
 })
@@ -176,26 +183,33 @@ useSchema({
       type: 'ListItem',
       position: 1,
       name: 'JavaScript',
-      item: 'https://example.com/javascript',
+      item: '/languages/javascript', // Relative URL - automatically normalized to absolute
     },
     {
       type: 'ListItem',
       position: 2,
       name: 'Python',
-      item: 'https://example.com/python',
+      item: 'https://www.python.org', // Absolute URL - used as-is
+    },
+    {
+      type: 'ListItem',
+      position: 3,
+      name: 'TypeScript',
+      item: '/languages/typescript', // Relative URL - automatically normalized to absolute
     },
   ],
   renderHtml: true,
   visuallyHidden: true,
 })
 
-// Person Schema
+// Person Schema with nested object
 useSchema({
   context: 'https://schema.org',
   type: 'Person',
   name: 'John Doe',
   jobTitle: 'Software Engineer',
-  url: 'https://example.com',
+  url: '/about', // Relative URL - automatically normalized to absolute URL
+  image: '/images/profile.jpg', // Relative URL from /public folder - automatically normalized
   // Control semantic HTML generation with renderHtml and visuallyHidden options
   renderHtml: false, // Disable semantic HTML generation
 })
@@ -205,6 +219,7 @@ useSchema({
 **Note:** 
 - `context` and `type` are automatically converted to `@context` and `@type` internally, so you can use them without quotes like regular properties. Nested objects are also converted automatically.
 - Use the `renderHtml` and `visuallyHidden` options to control semantic HTML generation and visual hiding.
+- **URL Normalization**: All `url`, `image`, `logo`, and `item` properties in the schema are automatically normalized to absolute URLs. Relative URLs are combined with the base URL (from `useRequestURL()` or `app.baseURL`), while absolute URLs (starting with `http://` or `https://`) remain unchanged. This normalization applies recursively to nested objects and arrays (e.g., `author.url`, `publisher.logo.url`, `sameAs[]`, `itemListElement[].item`).
 
 ## Verification
 
@@ -232,7 +247,7 @@ This page includes FAQPage Schema to help AI models and search engines understan
 
 ```vue
 <script setup lang="ts">
-useSchemaPage({
+useSchemaFaq({
   mainEntity: [
     {
       name: 'What is the Nuxt AEO module?',
@@ -249,13 +264,13 @@ useSchemaPage({
     {
       name: 'Can I use it immediately after installation?',
       acceptedAnswer: {
-        text: 'Yes! Once you install the module with `bun add nuxt-aeo` and add it to your `nuxt.config.ts`, you can start using it immediately. If you don\'t configure global schemas, a default Project schema will be automatically injected. You can also add schemas per page using useSchema() or useSchemaPage() composables.',
+        text: 'Yes! Once you install the module with `bun add nuxt-aeo` and add it to your `nuxt.config.ts`, you can start using it immediately. If you don\'t configure global schemas, a default Project schema will be automatically injected. You can also add schemas per page using useSchema() or useSchemaFaq() composables.',
       },
     },
     {
-      name: 'What is the difference between useSchemaPage() and useSchema()?',
+      name: 'What is the difference between useSchemaFaq() and useSchema()?',
       acceptedAnswer: {
-        text: 'useSchemaPage() is a specialized composable for FAQPage Schema that provides a simpler API for adding question-answer structures. useSchema() is a universal composable that can create any Schema.org type. Both support automatic semantic HTML generation and visual hiding options.',
+        text: 'useSchemaFaq() is a specialized composable for FAQPage Schema that provides a simpler API for adding question-answer structures. useSchema() is a universal composable that can create any Schema.org type. Both support automatic semantic HTML generation and visual hiding options.',
       },
     },
     {
@@ -277,7 +292,7 @@ useSchemaPage({
 
 - **Can I use it immediately after installation?**: Yes! Once installed and added to your config, you can start using it immediately. A default Project schema is automatically injected if no global schemas are configured.
 
-- **What is the difference between useSchemaPage() and useSchema()?**: useSchemaPage() is specialized for FAQPage Schema with a simpler API, while useSchema() is a universal composable for any Schema.org type.
+- **What is the difference between useSchemaFaq() and useSchema()?**: useSchemaFaq() is specialized for FAQPage Schema with a simpler API, while useSchema() is a universal composable for any Schema.org type.
 
 - **How does automatic semantic HTML generation work?**: When enabled (default), semantic HTML is automatically generated from schema data and hidden from users but accessible to LLMs and crawlers, improving AI model content understanding.
 

--- a/docs/content/1.guide/1.getting-started.md
+++ b/docs/content/1.guide/1.getting-started.md
@@ -27,7 +27,7 @@ Once installed, you can use it right away. The simplest example is adding a Sche
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-useSchemaPage({
+useSchemaFaq({
   mainEntity: [
     {
       name: 'What is the Nuxt AEO module?',
@@ -53,7 +53,7 @@ This page includes FAQPage Schema to help AI models and search engines understan
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-useSchemaPage({
+useSchemaFaq({
   mainEntity: [
     {
       name: 'What is AEO?',
@@ -70,7 +70,7 @@ useSchemaPage({
     {
       name: 'How do I get started?',
       acceptedAnswer: {
-        text: 'You can start using it immediately after installing the module. The simplest example is adding a Schema to an FAQ page. You can easily add question-answer structures using the useSchemaPage() function.',
+        text: 'You can start using it immediately after installing the module. The simplest example is adding a Schema to an FAQ page. You can easily add question-answer structures using the useSchemaFaq() function.',
       },
     },
   ],
@@ -82,7 +82,7 @@ useSchemaPage({
 
 - **What is AEO?**: A technique for optimizing structured data so that AI models and search engines can better understand web content
 - **What are the main features of the Nuxt AEO module?**: AI model optimization, search engine optimization, and automatic semantic HTML generation through Schema.org JSON-LD
-- **How do I get started?**: You can start immediately after installing the module by using the useSchemaPage() function
+- **How do I get started?**: You can start immediately after installing the module by using the useSchemaFaq() function
 
 ## Next Steps
 

--- a/docs/content/1.guide/2.installation.md
+++ b/docs/content/1.guide/2.installation.md
@@ -47,7 +47,7 @@ This page includes FAQPage Schema to help AI models and search engines understan
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-useSchemaPage({
+useSchemaFaq({
   mainEntity: [
     {
       name: 'What are the installation requirements?',

--- a/docs/content/1.guide/3.module-options.md
+++ b/docs/content/1.guide/3.module-options.md
@@ -42,23 +42,26 @@ export default defineNuxtConfig({
       {
         type: 'Organization',
         name: 'My Company',
-        url: 'https://www.example.com',
-        logo: 'https://www.example.com/logo.png',
+        url: '/', // Relative URL - will be normalized to absolute
+        logo: '/images/logo.png', // Relative URL - will be normalized to absolute
       },
       {
         type: 'Person',
         name: 'Yeonju Lee',
         alternateName: 'Dewdew',
         jobTitle: 'Software Engineer / CDO',
-        url: 'https://www.example.com',
-        image: 'https://www.example.com/profile.jpg',
+        url: 'https://www.example.com', // Absolute URL - used as-is
+        image: '/images/profile.jpg', // Relative URL - will be normalized to absolute
         knowsAbout: ['Nuxt3', 'TypeScript', 'Supabase'],
-        sameAs: ['https://github.com/dewdew'],
+        sameAs: [
+          'https://github.com/dewdew', // Absolute URL - used as-is
+          '/social/twitter', // Relative URL - will be normalized to absolute
+        ],
       },
       {
         type: 'WebSite',
         name: 'My Website',
-        url: 'https://www.example.com',
+        url: 'https://www.example.com', // Absolute URL - used as-is
         description: 'My awesome website',
       },
     ],
@@ -175,8 +178,8 @@ export default defineNuxtConfig({
       {
         type: 'Organization',
         name: 'My Company',
-        url: 'https://www.example.com',
-        logo: 'https://www.example.com/logo.png',
+        url: '/', // Relative URL - will be normalized to absolute
+        logo: '/images/logo.png', // Relative URL - will be normalized to absolute
         renderHtml: true,
         visuallyHidden: true,
       },
@@ -185,17 +188,20 @@ export default defineNuxtConfig({
         name: 'Yeonju Lee',
         alternateName: 'Dewdew',
         jobTitle: 'Software Engineer / CDO',
-        url: 'https://www.example.com',
-        image: 'https://www.example.com/profile.jpg',
+        url: 'https://www.example.com', // Absolute URL - used as-is
+        image: '/images/profile.jpg', // Relative URL - will be normalized to absolute
         knowsAbout: ['Nuxt3', 'TypeScript', 'Supabase'],
-        sameAs: ['https://github.com/dewdew'],
+        sameAs: [
+          'https://github.com/dewdew', // Absolute URL - used as-is
+          '/social/twitter', // Relative URL - will be normalized to absolute
+        ],
         renderHtml: true,
         visuallyHidden: true,
       },
       {
         type: 'WebSite',
         name: 'My Website',
-        url: 'https://www.example.com',
+        url: 'https://www.example.com', // Absolute URL - used as-is
         description: 'My awesome website',
       },
     ],
@@ -217,7 +223,7 @@ This page includes FAQPage Schema to help AI models and search engines understan
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-useSchemaPage({
+useSchemaFaq({
   mainEntity: [
     {
       name: 'Is global schema configuration required?',

--- a/docs/content/1.guide/4.semantic-html.md
+++ b/docs/content/1.guide/4.semantic-html.md
@@ -70,13 +70,13 @@ When `visuallyHidden: true` (default), the generated semantic HTML is hidden wit
 
 ## Usage
 
-### Using with useSchemaPage
+### Using with useSchemaFaq
 
-`useSchemaPage` is set to `renderHtml: true` by default:
+`useSchemaFaq` is set to `renderHtml: true` by default:
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-useSchemaPage({
+useSchemaFaq({
   mainEntity: [
     {
       name: 'Question 1',
@@ -120,6 +120,8 @@ export default defineNuxtConfig({
       {
         type: 'Organization',
         name: 'My Company',
+        url: '/', // Relative URL - will be normalized to absolute
+        logo: '/images/logo.png', // Relative URL - will be normalized to absolute
         renderHtml: true, // Set on individual schema
         visuallyHidden: true,
       },
@@ -146,7 +148,8 @@ useSchema({
   name: 'John Doe',
   alternateName: 'JD',
   jobTitle: 'Software Engineer',
-  url: 'https://example.com',
+  url: '/profile', // Relative URL - will be normalized to absolute
+  image: 'https://example.com/profile.jpg', // Absolute URL - used as-is
   knowsAbout: ['JavaScript', 'TypeScript'],
   renderHtml: true,
 })
@@ -177,7 +180,8 @@ useSchema({
   type: 'Organization',
   name: 'My Company',
   description: 'Company description',
-  url: 'https://example.com',
+  url: '/', // Relative URL - will be normalized to absolute
+  logo: '/images/logo.png', // Relative URL - will be normalized to absolute
   renderHtml: true,
 })
 </script>
@@ -209,7 +213,13 @@ useSchema({
       type: 'ListItem',
       position: 1,
       name: 'JavaScript',
-      item: 'https://example.com/javascript',
+      item: '/tech/javascript', // Relative URL - will be normalized to absolute
+    },
+    {
+      type: 'ListItem',
+      position: 2,
+      name: 'TypeScript',
+      item: 'https://www.typescriptlang.org', // Absolute URL - used as-is
     },
   ],
   renderHtml: true,
@@ -245,9 +255,11 @@ useSchema({
   headline: 'Article Title',
   description: 'Article description',
   datePublished: '2024-01-15',
+  image: '/images/article.jpg', // Relative URL - will be normalized to absolute
   author: {
     type: 'Person',
     name: 'John Doe',
+    url: 'https://example.com/author', // Absolute URL - used as-is
   },
   renderHtml: true,
 })
@@ -319,7 +331,7 @@ This page includes FAQPage Schema to help AI models and search engines understan
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-useSchemaPage({
+useSchemaFaq({
   mainEntity: [
     {
       name: 'Why is semantic HTML needed?',
@@ -330,7 +342,7 @@ useSchemaPage({
     {
       name: 'What is the default value of the renderHtml option?',
       acceptedAnswer: {
-        text: 'For useSchemaPage(), the default value of renderHtml is true, while for useSchema(), the default is false. In global configuration, the default value of renderHtml is also true.',
+        text: 'For useSchemaFaq(), the default value of renderHtml is true, while for useSchema(), the default is false. In global configuration, the default value of renderHtml is also true.',
       },
     },
     {
@@ -353,7 +365,7 @@ useSchemaPage({
 ### Question List
 
 - **Why is semantic HTML needed?**: JSON-LD alone may not be sufficient, so using semantic HTML together helps crawlers better understand content
-- **What is the default value of the renderHtml option?**: The default is true for useSchemaPage() and false for useSchema()
+- **What is the default value of the renderHtml option?**: The default is true for useSchemaFaq() and false for useSchema()
 - **Is the generated HTML visible to users?**: No, it is hidden with the visually-hidden class and not visible, but it is included in the HTML source
 - **Which Schema types generate semantic HTML?**: Generated for major types such as Person, Organization, ItemList, Article, and FAQPage
 

--- a/docs/content/1.guide/5.usage.md
+++ b/docs/content/1.guide/5.usage.md
@@ -5,20 +5,28 @@ description: How to use the composable functions of the Nuxt AEO module
 
 The Nuxt AEO module provides two main composable functions:
 
-- `useSchemaPage()`: A helper function for easily adding FAQPage Schema
+- `useSchemaFaq()`: A helper function for easily adding FAQPage Schema
 - `useSchema()`: A universal function for adding any Schema type
 
 ---
 
-## useSchemaPage
+## useSchemaFaq
 
 A dedicated composable for adding question-answer structures to FAQ pages.
+
+### URL Normalization
+
+Like `useSchema()`, `useSchemaFaq()` also automatically normalizes URLs:
+- **Absolute URLs** (starting with `http://` or `https://`): Used as-is
+- **Relative URLs**: Combined with the base URL (from `useRequestURL()` or `app.baseURL`)
+- **Recursive Processing**: URL normalization applies to nested objects and arrays
+- **Properties Processed**: `url`, `image`, `logo`, and `item` properties are automatically normalized
 
 ### Basic Usage
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-useSchemaPage({
+useSchemaFaq({
   mainEntity: [
     {
       name: 'What is the Nuxt AEO module?',
@@ -71,7 +79,7 @@ const faqs = [
 ]
 
 // Add FAQPage Schema
-useSchemaPage({
+useSchemaFaq({
   mainEntity: faqs.map(faq => ({
     name: faq.question,
     acceptedAnswer: {
@@ -100,22 +108,32 @@ useSchemaPage({
 
 A universal composable for adding any Schema type.
 
+### URL Normalization
+
+`useSchema()` automatically normalizes URLs in schema objects:
+- **Absolute URLs** (starting with `http://` or `https://`): Used as-is
+- **Relative URLs**: Combined with the base URL (from `useRequestURL()` or `app.baseURL`)
+- **Recursive Processing**: URL normalization applies to nested objects and arrays (e.g., `author.url`, `publisher.logo.url`, `sameAs[]`, `itemListElement[].item`)
+- **Properties Processed**: `url`, `image`, `logo`, and `item` properties are automatically normalized
+
+This ensures that all URLs in your schema are absolute URLs, which is required by Schema.org standards.
+
 ### Basic Usage
 
 Using `context` and `type` will automatically convert them to `@context` and `@type` internally:
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-// Organization Schema
+// Organization Schema with mixed absolute and relative URLs
 useSchema({
   context: 'https://schema.org',
   type: 'Organization',
   name: 'Example Company',
-  url: 'https://example.com',
-  logo: 'https://example.com/logo.png',
+  url: '/', // Relative URL - will be normalized to absolute
+  logo: '/images/logo.png', // Relative URL - will be normalized to absolute
 })
 
-// ItemList Schema
+// ItemList Schema with mixed absolute and relative URLs
 useSchema({
   context: 'https://schema.org',
   type: 'ItemList',
@@ -126,24 +144,25 @@ useSchema({
       type: 'ListItem',
       position: 1,
       name: 'JavaScript',
-      item: 'https://example.com/javascript',
+      item: '/tech/javascript', // Relative URL - will be normalized to absolute
     },
     {
       type: 'ListItem',
       position: 2,
       name: 'Python',
-      item: 'https://example.com/python',
+      item: 'https://www.python.org', // Absolute URL - used as-is
     },
   ],
 })
 
-// Person Schema
+// Person Schema with mixed absolute and relative URLs
 useSchema({
   context: 'https://schema.org',
   type: 'Person',
   name: 'John Doe',
   jobTitle: 'Software Engineer',
-  url: 'https://example.com',
+  url: '/profile', // Relative URL - will be normalized to absolute
+  image: 'https://example.com/profile.jpg', // Absolute URL - used as-is
 })
 </script>
 ```
@@ -182,12 +201,12 @@ useSchema({
   name: 'John Doe',
   alternateName: 'JD',
   jobTitle: 'Software Engineer',
-  url: 'https://example.com',
-  image: 'https://example.com/profile.jpg',
+  url: '/profile', // Relative URL - will be normalized to absolute
+  image: '/images/profile.jpg', // Relative URL - will be normalized to absolute
   knowsAbout: ['JavaScript', 'TypeScript', 'Vue.js'],
   sameAs: [
-    'https://github.com/johndoe',
-    'https://twitter.com/johndoe',
+    'https://github.com/johndoe', // Absolute URL - used as-is
+    '/social/twitter', // Relative URL - will be normalized to absolute
   ],
 })
 </script>
@@ -201,12 +220,12 @@ useSchema({
   context: 'https://schema.org',
   type: 'Organization',
   name: 'My Company',
-  url: 'https://www.example.com',
-  logo: 'https://www.example.com/logo.png',
+  url: '/', // Relative URL - will be normalized to absolute
+  logo: '/images/logo.png', // Relative URL - will be normalized to absolute
   description: 'A great company',
   sameAs: [
-    'https://www.facebook.com/example',
-    'https://www.twitter.com/example',
+    'https://www.facebook.com/example', // Absolute URL - used as-is
+    '/social/twitter', // Relative URL - will be normalized to absolute
   ],
 })
 </script>
@@ -226,19 +245,19 @@ useSchema({
       type: 'ListItem',
       position: 1,
       name: 'JavaScript',
-      item: 'https://example.com/javascript',
+      item: '/tech/javascript', // Relative URL - will be normalized to absolute
     },
     {
       type: 'ListItem',
       position: 2,
       name: 'Python',
-      item: 'https://example.com/python',
+      item: 'https://www.python.org', // Absolute URL - used as-is
     },
     {
       type: 'ListItem',
       position: 3,
       name: 'TypeScript',
-      item: 'https://example.com/typescript',
+      item: '/tech/typescript', // Relative URL - will be normalized to absolute
     },
   ],
 })
@@ -257,10 +276,19 @@ useSchema({
   author: {
     type: 'Person',
     name: 'John Doe',
+    url: 'https://example.com/author', // Absolute URL - used as-is
   },
   datePublished: '2024-01-01',
   dateModified: '2024-01-02',
-  image: 'https://example.com/article-image.jpg',
+  image: '/images/article.jpg', // Relative URL - will be normalized to absolute
+  publisher: {
+    type: 'Organization',
+    name: 'Example Company',
+    logo: {
+      type: 'ImageObject',
+      url: '/logo.png', // Relative URL - will be normalized to absolute
+    },
+  },
 })
 </script>
 ```
@@ -324,18 +352,18 @@ This page includes FAQPage Schema to help AI models and search engines understan
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-useSchemaPage({
+useSchemaFaq({
   mainEntity: [
     {
-      name: 'What is the difference between useSchemaPage() and useSchema()?',
+      name: 'What is the difference between useSchemaFaq() and useSchema()?',
       acceptedAnswer: {
-        text: 'useSchemaPage() is a dedicated function for easily adding FAQPage Schema, and its renderHtml default value is true. useSchema() is a universal function that can add any Schema type, and its renderHtml default value is false.',
+        text: 'useSchemaFaq() is a dedicated function for easily adding FAQPage Schema, and its renderHtml default value is true. useSchema() is a universal function that can add any Schema type, and its renderHtml default value is false.',
       },
     },
     {
-      name: 'When should I use useSchemaPage()?',
+      name: 'When should I use useSchemaFaq()?',
       acceptedAnswer: {
-        text: 'It is recommended to use useSchemaPage() on FAQ pages or pages with question-answer structures. You can easily add FAQPage Schema, and semantic HTML is also automatically generated.',
+        text: 'It is recommended to use useSchemaFaq() on FAQ pages or pages with question-answer structures. You can easily add FAQPage Schema, and semantic HTML is also automatically generated.',
       },
     },
     {
@@ -347,13 +375,13 @@ useSchemaPage({
     {
       name: 'Can I add multiple schemas to one page?',
       acceptedAnswer: {
-        text: 'Yes, you can add multiple schemas by calling useSchema() and useSchemaPage() multiple times. Each call independently generates JSON-LD and adds it to the page.',
+        text: 'Yes, you can add multiple schemas by calling useSchema() and useSchemaFaq() multiple times. Each call independently generates JSON-LD and adds it to the page.',
       },
     },
     {
       name: 'Can I use global schemas and page-specific schemas together?',
       acceptedAnswer: {
-        text: 'Yes, global schemas are automatically injected into all pages, and you can add additional schemas per page using useSchema() or useSchemaPage(). Both are applied together.',
+        text: 'Yes, global schemas are automatically injected into all pages, and you can add additional schemas per page using useSchema() or useSchemaFaq(). Both are applied together.',
       },
     },
   ],
@@ -363,8 +391,8 @@ useSchemaPage({
 
 ### Question List
 
-- **What is the difference between useSchemaPage() and useSchema()?**: useSchemaPage() is a dedicated function for FAQPage with renderHtml default true, while useSchema() is a universal function with renderHtml default false
-- **When should I use useSchemaPage()?**: Use it on FAQ pages or pages with question-answer structures
+- **What is the difference between useSchemaFaq() and useSchema()?**: useSchemaFaq() is a dedicated function for FAQPage with renderHtml default true, while useSchema() is a universal function with renderHtml default false
+- **When should I use useSchemaFaq()?**: Use it on FAQ pages or pages with question-answer structures
 - **Are context and type automatically converted?**: Yes, they are automatically converted to @context and @type, and this also applies to nested objects
 - **Can I add multiple schemas to one page?**: Yes, you can add multiple schemas by calling them multiple times
 - **Can I use global schemas and page-specific schemas together?**: Yes, both are applied together

--- a/docs/content/3.examples/1.person.md
+++ b/docs/content/3.examples/1.person.md
@@ -20,10 +20,13 @@ export default defineNuxtConfig({
         name: 'Yeonju Lee',
         alternateName: 'Dewdew',
         jobTitle: 'Software Engineer / CDO',
-        url: 'https://www.example.com',
-        image: 'https://www.example.com/profile.jpg',
+        url: '/profile', // Relative URL - will be normalized to absolute
+        image: '/images/profile.jpg', // Relative URL - will be normalized to absolute
         knowsAbout: ['Nuxt3', 'TypeScript', 'Supabase'],
-        sameAs: ['https://github.com/dewdew'],
+        sameAs: [
+          'https://github.com/dewdew', // Absolute URL - used as-is
+          '/social/twitter', // Relative URL - will be normalized to absolute
+        ],
         renderHtml: true, // Generate semantic HTML
         visuallyHidden: true, // Visually hide
       },
@@ -37,6 +40,12 @@ export default defineNuxtConfig({
 
 To add Person Schema only on specific pages, use the `useSchema()` composable:
 
+> **Note**: `useSchema()` automatically normalizes URLs:
+> - Absolute URLs (starting with `http://` or `https://`) are used as-is
+> - Relative URLs are combined with the base URL (from `useRequestURL()` or `app.baseURL`)
+> - URL normalization applies recursively to nested objects and arrays (e.g., `sameAs[]`, `worksFor.url`)
+> - Processes `url`, `image`, `logo`, and `item` properties throughout the schema
+
 ```vue [pages/example.vue]
 <script setup lang="ts">
 useSchema({
@@ -44,9 +53,13 @@ useSchema({
   type: 'Person',
   name: 'John Doe',
   jobTitle: 'Software Engineer',
-  url: 'https://example.com',
-  image: 'https://example.com/profile.jpg',
+  url: '/profile', // Relative URL - will be normalized to absolute
+  image: '/images/profile.jpg', // Relative URL - will be normalized to absolute
   knowsAbout: ['JavaScript', 'TypeScript', 'Vue.js'],
+  sameAs: [
+    'https://github.com/johndoe', // Absolute URL - used as-is
+    '/social/twitter', // Relative URL - will be normalized to absolute
+  ],
   renderHtml: true, // Generate semantic HTML
   visuallyHidden: true, // Visually hide
 })
@@ -68,14 +81,14 @@ export default defineNuxtConfig({
         name: 'Yeonju Lee',
         alternateName: 'Dewdew',
         jobTitle: 'Software Engineer / CDO',
-        url: 'https://www.example.com',
-        image: 'https://www.example.com/profile.jpg',
+        url: '/profile', // Relative URL - will be normalized to absolute
+        image: '/images/profile.jpg', // Relative URL - will be normalized to absolute
         description: 'Full-stack developer specializing in Nuxt and Vue.js',
         knowsAbout: ['Nuxt3', 'TypeScript', 'Supabase', 'Vue.js'],
         sameAs: [
-          'https://github.com/dewdew',
-          'https://twitter.com/dewdew',
-          'https://linkedin.com/in/dewdew',
+          'https://github.com/dewdew', // Absolute URL - used as-is
+          '/social/twitter', // Relative URL - will be normalized to absolute
+          'https://linkedin.com/in/dewdew', // Absolute URL - used as-is
         ],
         worksFor: {
           type: 'Organization',
@@ -94,19 +107,19 @@ export default defineNuxtConfig({
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-// Person data
+// Person data with mixed absolute and relative URLs
 const person = {
   name: 'John Doe',
   alternateName: 'johndoe',
   jobTitle: 'Software Engineer',
-  url: 'https://example.com',
-  image: 'https://example.com/profile.jpg',
+  url: '/profile', // Relative URL - will be normalized to absolute
+  image: '/images/profile.jpg', // Relative URL - will be normalized to absolute
   description: 'Full-stack developer with expertise in web application development.',
   knowsAbout: ['JavaScript', 'TypeScript', 'Vue.js', 'Nuxt', 'Node.js'],
   sameAs: [
-    'https://github.com/johndoe',
-    'https://twitter.com/johndoe',
-    'https://linkedin.com/in/johndoe',
+    'https://github.com/johndoe', // Absolute URL - used as-is
+    '/social/twitter', // Relative URL - will be normalized to absolute
+    'https://linkedin.com/in/johndoe', // Absolute URL - used as-is
   ],
   worksFor: {
     name: 'Example Company',
@@ -255,7 +268,7 @@ This page includes FAQPage Schema to help AI models and search engines understan
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-useSchemaPage({
+useSchemaFaq({
   mainEntity: [
     {
       name: 'When should I use Person Schema?',

--- a/docs/content/3.examples/2.organization.md
+++ b/docs/content/3.examples/2.organization.md
@@ -19,8 +19,8 @@ export default defineNuxtConfig({
       {
         type: 'Organization',
         name: 'My Company',
-        url: 'https://www.example.com',
-        logo: 'https://www.example.com/logo.png',
+        url: '/', // Relative URL - will be normalized to absolute
+        logo: '/images/logo.png', // Relative URL - will be normalized to absolute
         description: 'A company developing Nuxt modules for AI Engine Optimization',
         renderHtml: true, // Generate semantic HTML
         visuallyHidden: true, // Visually hide
@@ -35,15 +35,25 @@ export default defineNuxtConfig({
 
 To add Organization Schema only on specific pages, use the `useSchema()` composable:
 
+> **Note**: `useSchema()` automatically normalizes URLs:
+> - Absolute URLs (starting with `http://` or `https://`) are used as-is
+> - Relative URLs are combined with the base URL (from `useRequestURL()` or `app.baseURL`)
+> - URL normalization applies recursively to nested objects and arrays (e.g., `sameAs[]`, `logo.url`)
+> - Processes `url`, `image`, `logo`, and `item` properties throughout the schema
+
 ```vue [pages/example.vue]
 <script setup lang="ts">
 useSchema({
   context: 'https://schema.org',
   type: 'Organization',
   name: 'Example Company',
-  url: 'https://example.com',
-  logo: 'https://example.com/logo.png',
+  url: '/', // Relative URL - will be normalized to absolute
+  logo: '/images/logo.png', // Relative URL - will be normalized to absolute
   description: 'Example Company provides the best services.',
+  sameAs: [
+    'https://github.com/example', // Absolute URL - used as-is
+    '/social/twitter', // Relative URL - will be normalized to absolute
+  ],
   renderHtml: true, // Generate semantic HTML
   visuallyHidden: true, // Visually hide
 })
@@ -63,14 +73,14 @@ export default defineNuxtConfig({
       {
         type: 'Organization',
         name: 'Nuxt AEO Project',
-        url: 'https://www.example.com',
+        url: '/', // Relative URL - will be normalized to absolute
         description: 'AI Engine Optimization module for Nuxt',
-        logo: 'https://www.example.com/logo.png',
+        logo: '/images/logo.png', // Relative URL - will be normalized to absolute
         // Social media links
         sameAs: [
-          'https://github.com/your-org/nuxt-aeo',
-          'https://twitter.com/your-org',
-          'https://linkedin.com/company/your-org',
+          'https://github.com/your-org/nuxt-aeo', // Absolute URL - used as-is
+          '/social/twitter', // Relative URL - will be normalized to absolute
+          'https://linkedin.com/company/your-org', // Absolute URL - used as-is
         ],
         // Contact information
         contactPoint: {
@@ -92,15 +102,15 @@ export default defineNuxtConfig({
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-// Organization data
+// Organization data with mixed absolute and relative URLs
 const organization = {
   name: 'Example Company',
-  url: 'https://example.com',
+  url: '/', // Relative URL - will be normalized to absolute
   description: 'Example Company provides the best services.',
-  logo: 'https://example.com/logo.png',
+  logo: '/images/logo.png', // Relative URL - will be normalized to absolute
   sameAs: [
-    'https://github.com/example',
-    'https://twitter.com/example',
+    'https://github.com/example', // Absolute URL - used as-is
+    '/social/twitter', // Relative URL - will be normalized to absolute
   ],
   contactPoint: {
     telephone: '+1-555-123-4567',
@@ -233,7 +243,7 @@ This page includes FAQPage Schema to help AI models and search engines understan
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-useSchemaPage({
+useSchemaFaq({
   mainEntity: [
     {
       name: 'When should I use Organization Schema?',

--- a/docs/content/3.examples/3.itemlist.md
+++ b/docs/content/3.examples/3.itemlist.md
@@ -10,6 +10,12 @@ Using ItemList Schema allows you to structure information about lists, catalogs,
 
 To add ItemList Schema on specific pages, use the `useSchema()` composable:
 
+> **Note**: `useSchema()` automatically normalizes URLs:
+> - Absolute URLs (starting with `http://` or `https://`) are used as-is
+> - Relative URLs are combined with the base URL (from `useRequestURL()` or `app.baseURL`)
+> - URL normalization applies recursively to nested objects and arrays (e.g., `itemListElement[].item`)
+> - Processes `url`, `image`, `logo`, and `item` properties throughout the schema
+
 ```vue [pages/example.vue]
 <script setup lang="ts">
 useSchema({
@@ -22,13 +28,13 @@ useSchema({
       type: 'ListItem',
       position: 1,
       name: 'Product 1',
-      item: 'https://example.com/products/1',
+      item: '/products/1', // Relative URL - will be normalized to absolute
     },
     {
       type: 'ListItem',
       position: 2,
       name: 'Product 2',
-      item: 'https://example.com/products/2',
+      item: 'https://example.com/products/2', // Absolute URL - used as-is
     },
   ],
   renderHtml: true, // Generate semantic HTML
@@ -43,7 +49,7 @@ useSchema({
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-// Catalog data
+// Catalog data with mixed absolute and relative URLs
 const catalog = {
   name: 'Top 10 Best Selling Products',
   description: 'Our most popular products this month based on sales data.',
@@ -51,31 +57,31 @@ const catalog = {
     {
       position: 1,
       name: 'Premium Wireless Headphones',
-      url: 'https://example.com/products/headphones',
+      url: '/products/headphones', // Relative URL - will be normalized to absolute
       description: 'High-quality wireless headphones with noise cancellation.',
     },
     {
       position: 2,
       name: 'Smart Watch Pro',
-      url: 'https://example.com/products/smartwatch',
+      url: 'https://example.com/products/smartwatch', // Absolute URL - used as-is
       description: 'Advanced smartwatch with health tracking features.',
     },
     {
       position: 3,
       name: 'Portable Laptop Stand',
-      url: 'https://example.com/products/laptop-stand',
+      url: '/products/laptop-stand', // Relative URL - will be normalized to absolute
       description: 'Ergonomic laptop stand for better posture.',
     },
     {
       position: 4,
       name: 'Mechanical Keyboard',
-      url: 'https://example.com/products/keyboard',
+      url: '/products/keyboard', // Relative URL - will be normalized to absolute
       description: 'RGB mechanical keyboard with customizable keys.',
     },
     {
       position: 5,
       name: 'USB-C Hub',
-      url: 'https://example.com/products/usb-hub',
+      url: 'https://example.com/products/usb-hub', // Absolute URL - used as-is
       description: 'Multi-port USB-C hub for laptops and tablets.',
     },
   ],
@@ -297,7 +303,7 @@ This page includes FAQPage Schema to help AI models and search engines understan
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-useSchemaPage({
+useSchemaFaq({
   mainEntity: [
     {
       name: 'When should I use ItemList Schema?',

--- a/docs/content/3.examples/4.article.md
+++ b/docs/content/3.examples/4.article.md
@@ -10,6 +10,12 @@ Using Article Schema allows you to structure information about blog posts, news 
 
 To add Article Schema on specific pages, use the `useSchema()` composable:
 
+> **Note**: `useSchema()` automatically normalizes URLs:
+> - Absolute URLs (starting with `http://` or `https://`) are used as-is
+> - Relative URLs are combined with the base URL (from `useRequestURL()` or `app.baseURL`)
+> - URL normalization applies recursively to nested objects and arrays (e.g., `author.url`, `publisher.logo.url`, `image`)
+> - Processes `url`, `image`, `logo`, and `item` properties throughout the schema
+
 ```vue [pages/example.vue]
 <script setup lang="ts">
 useSchema({
@@ -39,23 +45,23 @@ useSchema({
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-// Article data
+// Article data with mixed absolute and relative URLs
 const article = {
   headline: 'Getting Started with Nuxt AEO Module',
   description: 'Learn how to implement AI Engine Optimization in your Nuxt application using Schema.org JSON-LD structured data.',
-  image: 'https://example.com/images/nuxt-aeo.jpg',
+  image: '/images/nuxt-aeo.jpg', // Relative URL - will be normalized to absolute
   datePublished: '2024-01-15',
   dateModified: '2024-01-20',
   author: {
     name: 'Yeonju Lee',
     jobTitle: 'Software Engineer / CDO',
-    image: 'https://example.com/authors/yeonju.jpg',
-    url: 'https://example.com/authors/yeonju',
+    image: '/images/authors/yeonju.jpg', // Relative URL - will be normalized to absolute
+    url: 'https://example.com/authors/yeonju', // Absolute URL - used as-is
   },
   publisher: {
     name: 'Nuxt AEO Project',
     logo: {
-      url: 'https://example.com/logo.png',
+      url: '/logo.png', // Relative URL - will be normalized to absolute
     },
   },
   keywords: ['Nuxt', 'AEO', 'Schema.org', 'SEO', 'AI'],
@@ -338,7 +344,7 @@ This page includes FAQPage Schema to help AI models and search engines understan
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-useSchemaPage({
+useSchemaFaq({
   mainEntity: [
     {
       name: 'When should I use Article Schema?',

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -211,7 +211,7 @@ orientation: horizontal
     ::::tabs-item{icon="i-simple-icons-nuxtdotjs" label="pages/index.vue"}
     ```vue [pages/index.vue]
     <script setup lang="ts">
-    useSchemaPage({
+    useSchemaFaq({
       mainEntity: [
         {
           name: 'What is the Nuxt AEO module?',
@@ -222,19 +222,19 @@ orientation: horizontal
         {
           name: 'What Schema types are supported?',
           acceptedAnswer: {
-            text: 'Nuxt AEO supports various Schema.org types including Person, Organization, Article, ItemList, and more. You can configure both global schemas and page-specific schemas through useSchema() and useSchemaPage() composables.',
+            text: 'Nuxt AEO supports various Schema.org types including Person, Organization, Article, ItemList, and more. You can configure both global schemas and page-specific schemas through useSchema() and useSchemaFaq() composables.',
           },
         },
         {
           name: 'Can I use it immediately after installation?',
           acceptedAnswer: {
-            text: 'Yes! Nuxt AEO can be used immediately after installation. Once you install the module and add it to nuxt.config.ts, you can define schemas using useSchema() or useSchemaPage() composables. It provides default behavior without additional configuration.',
+            text: 'Yes! Nuxt AEO can be used immediately after installation. Once you install the module and add it to nuxt.config.ts, you can define schemas using useSchema() or useSchemaFaq() composables. It provides default behavior without additional configuration.',
           },
         },
         {
-          name: 'What is the difference between useSchemaPage() and useSchema()?',
+          name: 'What is the difference between useSchemaFaq() and useSchema()?',
           acceptedAnswer: {
-            text: 'useSchema() is used to define schemas that describe the main content of a page (e.g., Article, Person), while useSchemaPage() is used to define metadata about the page itself (e.g., FAQPage, BreadcrumbList). You can use both composables together to structure both page content and metadata.',
+            text: 'useSchema() is used to define schemas that describe the main content of a page (e.g., Article, Person), while useSchemaFaq() is used to define metadata about the page itself (e.g., FAQPage, BreadcrumbList). You can use both composables together to structure both page content and metadata.',
           },
         },
       ],
@@ -262,14 +262,14 @@ orientation: horizontal
         FAQPage Schema Example.
 
         #description
-        Learn how to use useSchemaPage() composable to add FAQPage schema for better AI and search engine understanding.
+        Learn how to use useSchemaFaq() composable to add FAQPage schema for better AI and search engine understanding.
         ::::::
       :::::
     ::::
   :::
 
 #title{unwrap="p" class="!my-0 !leading-tight"}
-Add FAQPage schema with [useSchemaPage()]{.text-(--ui-secondary)} composable
+Add FAQPage schema with [useSchemaFaq()]{.text-(--ui-secondary)} composable
 
 #features
   :::u-page-feature
@@ -300,7 +300,7 @@ Add FAQPage schema with [useSchemaPage()]{.text-(--ui-secondary)} composable
   :::u-button
   ---
   color: neutral
-  label: Learn more about useSchemaPage()
+  label: Learn more about useSchemaFaq()
   to: /guide/usage
   trailingIcon: i-lucide-arrow-right
   variant: subtle

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-aeo",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Nuxt module for AI Engine Optimization (AEO) using Schema.org JSON-LD structured data",
   "keywords": [
     "nuxt",

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,6 +1,8 @@
 export default defineNuxtConfig({
   modules: ['nuxt-aeo'],
-  
+
+  devtools: { enabled: true },
+
   app: {
     head: {
       link: [
@@ -12,8 +14,6 @@ export default defineNuxtConfig({
       ],
     },
   },
-
-  devtools: { enabled: true },
   /**
    * AEO (AI Engine Optimization) module configuration
    * Supports AI model and search engine optimization through Schema.org JSON-LD.

--- a/playground/pages/article.vue
+++ b/playground/pages/article.vue
@@ -73,22 +73,23 @@
 
 <script setup lang="ts">
 // Article data
+// Note: Mix of absolute and relative URLs to demonstrate URL normalization
 const article = {
   headline: 'Getting Started with Nuxt AEO Module',
   description: 'Learn how to implement AI Engine Optimization in your Nuxt application using Schema.org JSON-LD structured data.',
-  image: 'https://example.com/images/nuxt-aeo.jpg',
+  image: '/images/nuxt-aeo.jpg', // Relative URL - will be normalized to absolute
   datePublished: '2024-01-15',
   dateModified: '2024-01-20',
   author: {
     name: 'Yeonju Lee',
     jobTitle: 'Software Engineer / CDO',
-    image: 'https://example.com/authors/yeonju.jpg',
-    url: 'https://example.com/authors/yeonju',
+    image: '/authors/yeonju.jpg', // Relative URL - will be normalized to absolute
+    url: 'https://example.com/authors/yeonju', // Absolute URL - used as-is
   },
   publisher: {
     name: 'Nuxt AEO Project',
     logo: {
-      url: 'https://example.com/logo.png',
+      url: '/logo.png', // Relative URL - will be normalized to absolute
     },
   },
   keywords: ['Nuxt', 'AEO', 'Schema.org', 'SEO', 'AI'],
@@ -122,6 +123,10 @@ function formatDate(dateString: string): string {
 }
 
 // Add Article Schema
+// Note: useSchema() automatically normalizes URLs:
+// - Absolute URLs (http:// or https://) are used as-is
+// - Relative URLs are combined with the base URL (from useRequestURL() or app.baseURL)
+// - URL normalization applies recursively to nested objects (e.g., author.url, publisher.logo.url)
 useSchema({
   context: 'https://schema.org',
   type: 'Article',
@@ -152,7 +157,8 @@ useSchema({
 })
 
 // Add FAQPage Schema for Article Schema-related questions
-useSchemaPage({
+// Note: useSchemaFaq() also automatically normalizes URLs like useSchema()
+useSchemaFaq({
   mainEntity: [
     {
       name: 'When should I use Article Schema?',

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -83,6 +83,7 @@ document.querySelectorAll('script[type="application/ld+json"]').forEach(script =
 
 <script setup lang="ts">
 // ItemList Schema data (added per page)
+// Note: Mix of absolute and relative URLs to demonstrate URL normalization
 const itemListData = {
   name: 'Top 5 Popular Technologies',
   description: 'Most popular technologies in 2024',
@@ -90,27 +91,27 @@ const itemListData = {
     {
       position: 1,
       name: 'Nuxt 4',
-      item: 'https://nuxt.com',
+      item: 'https://nuxt.com', // Absolute URL - used as-is
     },
     {
       position: 2,
       name: 'TypeScript',
-      item: 'https://www.typescriptlang.org',
+      item: '/tech/typescript', // Relative URL - will be normalized to absolute
     },
     {
       position: 3,
       name: 'Vue 3',
-      item: 'https://vuejs.org',
+      item: 'https://vuejs.org', // Absolute URL - used as-is
     },
     {
       position: 4,
       name: 'Vite',
-      item: 'https://vitejs.dev',
+      item: '/tech/vite', // Relative URL - will be normalized to absolute
     },
     {
       position: 5,
       name: 'Tailwind CSS',
-      item: 'https://tailwindcss.com',
+      item: 'https://tailwindcss.com', // Absolute URL - used as-is
     },
   ],
 }
@@ -118,6 +119,10 @@ const itemListData = {
 // Add ItemList Schema to page head (page-specific schema)
 // Use useSchema directly to add ItemList Schema
 // Also automatically generate semantic HTML with renderHtml: true
+// Note: useSchema() automatically normalizes URLs:
+// - Absolute URLs (http:// or https://) are used as-is
+// - Relative URLs are combined with the base URL (from useRequestURL() or app.baseURL)
+// - URL normalization applies recursively to nested objects and arrays
 useSchema({
   context: 'https://schema.org',
   type: 'ItemList',
@@ -134,7 +139,8 @@ useSchema({
 })
 
 // Add FAQPage Schema for module-related questions
-useSchemaPage({
+// Note: useSchemaFaq() also automatically normalizes URLs like useSchema()
+useSchemaFaq({
   mainEntity: [
     {
       name: 'What are the main features of the Nuxt AEO module?',
@@ -151,13 +157,13 @@ useSchemaPage({
     {
       name: 'How do I configure global schemas?',
       acceptedAnswer: {
-        text: 'Configure schemas in the aeo.schemas array in the nuxt.config.ts file, and they will be automatically injected into all pages. Global schemas are used for information that applies to the entire site, such as Organization and Person. Page-specific schemas can be added to individual pages using useSchema() or useSchemaPage().',
+        text: 'Configure schemas in the aeo.schemas array in the nuxt.config.ts file, and they will be automatically injected into all pages. Global schemas are used for information that applies to the entire site, such as Organization and Person. Page-specific schemas can be added to individual pages using useSchema() or useSchemaFaq().',
       },
     },
     {
-      name: 'What is the difference between useSchemaPage() and useSchema()?',
+      name: 'What is the difference between useSchemaFaq() and useSchema()?',
       acceptedAnswer: {
-        text: 'useSchema() is used to add general Schema.org schemas (Person, Organization, Article, etc.), while useSchemaPage() is used to add page metadata and FAQPage schema. useSchemaPage() automatically generates FAQPage Schema to help AI models understand the main questions and answers on the page.',
+        text: 'useSchema() is used to add general Schema.org schemas (Person, Organization, Article, etc.), while useSchemaFaq() is used to add page metadata and FAQPage schema. useSchemaFaq() automatically generates FAQPage Schema to help AI models understand the main questions and answers on the page.',
       },
     },
   ],

--- a/playground/pages/itemlist.vue
+++ b/playground/pages/itemlist.vue
@@ -31,6 +31,7 @@
 
 <script setup lang="ts">
 // Catalog data
+// Note: Mix of absolute and relative URLs to demonstrate URL normalization
 const catalog = {
   name: 'Top 10 Best Selling Products',
   description: 'Our most popular products this month based on sales data.',
@@ -38,37 +39,41 @@ const catalog = {
     {
       position: 1,
       name: 'Premium Wireless Headphones',
-      url: 'https://example.com/products/headphones',
+      url: '/products/headphones', // Relative URL - will be normalized to absolute
       description: 'High-quality wireless headphones with noise cancellation.',
     },
     {
       position: 2,
       name: 'Smart Watch Pro',
-      url: 'https://example.com/products/smartwatch',
+      url: 'https://example.com/products/smartwatch', // Absolute URL - used as-is
       description: 'Advanced smartwatch with health tracking features.',
     },
     {
       position: 3,
       name: 'Portable Laptop Stand',
-      url: 'https://example.com/products/laptop-stand',
+      url: '/products/laptop-stand', // Relative URL - will be normalized to absolute
       description: 'Ergonomic laptop stand for better posture.',
     },
     {
       position: 4,
       name: 'Mechanical Keyboard',
-      url: 'https://example.com/products/keyboard',
+      url: '/products/keyboard', // Relative URL - will be normalized to absolute
       description: 'RGB mechanical keyboard with customizable keys.',
     },
     {
       position: 5,
       name: 'USB-C Hub',
-      url: 'https://example.com/products/usb-hub',
+      url: 'https://example.com/products/usb-hub', // Absolute URL - used as-is
       description: 'Multi-port USB-C hub for laptops and tablets.',
     },
   ],
 }
 
 // Add ItemList Schema
+// Note: useSchema() automatically normalizes URLs:
+// - Absolute URLs (http:// or https://) are used as-is
+// - Relative URLs are combined with the base URL (from useRequestURL() or app.baseURL)
+// - URL normalization applies recursively to nested objects and arrays (e.g., itemListElement[].item)
 useSchema({
   context: 'https://schema.org',
   type: 'ItemList',
@@ -85,7 +90,8 @@ useSchema({
 })
 
 // Add FAQPage Schema for ItemList Schema-related questions
-useSchemaPage({
+// Note: useSchemaFaq() also automatically normalizes URLs like useSchema()
+useSchemaFaq({
   mainEntity: [
     {
       name: 'When should I use ItemList Schema?',

--- a/playground/pages/organization.vue
+++ b/playground/pages/organization.vue
@@ -43,14 +43,15 @@
 
 <script setup lang="ts">
 // Organization data
+// Note: Mix of absolute and relative URLs to demonstrate URL normalization
 const organization = {
   name: 'Example Company',
-  url: 'https://example.com',
+  url: '/', // Relative URL - will be normalized to absolute
   description: 'Example Company provides the best services.',
-  logo: 'https://example.com/logo.png',
+  logo: '/images/logo.png', // Relative URL - will be normalized to absolute
   sameAs: [
-    'https://github.com/example',
-    'https://twitter.com/example',
+    'https://github.com/example', // Absolute URL - used as-is
+    '/social/twitter', // Relative URL - will be normalized to absolute
   ],
   contactPoint: {
     telephone: '+1-555-123-4567',
@@ -60,6 +61,10 @@ const organization = {
 }
 
 // Add Organization Schema
+// Note: useSchema() automatically normalizes URLs:
+// - Absolute URLs (http:// or https://) are used as-is
+// - Relative URLs are combined with the base URL (from useRequestURL() or app.baseURL)
+// - URL normalization applies recursively to nested objects and arrays
 useSchema({
   context: 'https://schema.org',
   type: 'Organization',
@@ -79,7 +84,8 @@ useSchema({
 })
 
 // Add FAQPage Schema for Organization Schema-related questions
-useSchemaPage({
+// Note: useSchemaFaq() also automatically normalizes URLs like useSchema()
+useSchemaFaq({
   mainEntity: [
     {
       name: 'When should I use Organization Schema?',

--- a/playground/pages/person.vue
+++ b/playground/pages/person.vue
@@ -70,18 +70,19 @@
 
 <script setup lang="ts">
 // Person data
+// Note: Mix of absolute and relative URLs to demonstrate URL normalization
 const person = {
   name: 'John Doe',
   alternateName: 'johndoe',
   jobTitle: 'Software Engineer',
-  url: 'https://example.com',
-  image: 'https://example.com/profile.jpg',
+  url: '/profile', // Relative URL - will be normalized to absolute
+  image: '/images/profile.jpg', // Relative URL - will be normalized to absolute
   description: 'Full-stack developer with expertise in web application development.',
   knowsAbout: ['JavaScript', 'TypeScript', 'Vue.js', 'Nuxt', 'Node.js'],
   sameAs: [
-    'https://github.com/johndoe',
-    'https://twitter.com/johndoe',
-    'https://linkedin.com/in/johndoe',
+    'https://github.com/johndoe', // Absolute URL - used as-is
+    '/social/twitter', // Relative URL - will be normalized to absolute
+    'https://linkedin.com/in/johndoe', // Absolute URL - used as-is
   ],
   worksFor: {
     name: 'Example Company',
@@ -89,6 +90,10 @@ const person = {
 }
 
 // Add Person Schema
+// Note: useSchema() automatically normalizes URLs:
+// - Absolute URLs (http:// or https://) are used as-is
+// - Relative URLs are combined with the base URL (from useRequestURL() or app.baseURL)
+// - URL normalization applies recursively to nested objects and arrays (e.g., sameAs[], worksFor.url)
 useSchema({
   context: 'https://schema.org',
   type: 'Person',
@@ -109,7 +114,8 @@ useSchema({
 })
 
 // Add FAQPage Schema for Person Schema-related questions
-useSchemaPage({
+// Note: useSchemaFaq() also automatically normalizes URLs like useSchema()
+useSchemaFaq({
   mainEntity: [
     {
       name: 'When should I use Person Schema?',

--- a/src/runtime/composables/useSchema.ts
+++ b/src/runtime/composables/useSchema.ts
@@ -4,7 +4,112 @@
  * Includes automatic semantic HTML generation
  */
 
-import { useHead } from '#app'
+import { useHead, useRequestURL, useRuntimeConfig } from '#app'
+
+/**
+ * Get base URL for URL normalization
+ * Uses useRequestURL() origin if available, otherwise falls back to app.baseURL
+ */
+function getBaseUrl(): string {
+  try {
+    // Try to use useRequestURL() if available (SSR/client)
+    const requestUrl = useRequestURL()
+    if (requestUrl?.origin) {
+      return requestUrl.origin
+    }
+  }
+  catch {
+    // useRequestURL() may not be available in all contexts
+  }
+
+  try {
+    // Fall back to app.baseURL from runtime config
+    const config = useRuntimeConfig()
+    const appConfig = config.app as { baseURL?: string } | undefined
+    const baseURL = appConfig?.baseURL
+    if (baseURL) {
+      // If baseURL is absolute, return it; otherwise construct from origin
+      if (baseURL.startsWith('http://') || baseURL.startsWith('https://')) {
+        return new URL(baseURL).origin
+      }
+      // If baseURL is relative, try to construct absolute URL
+      // In browser, use window.location.origin
+      if (import.meta.client && typeof window !== 'undefined') {
+        return window.location.origin
+      }
+    }
+  }
+  catch {
+    // Runtime config may not be available
+  }
+
+  // Final fallback: use window.location.origin in browser
+  if (import.meta.client && typeof window !== 'undefined') {
+    return window.location.origin
+  }
+
+  // Last resort: return empty string (will cause URL constructor to throw, but that's handled)
+  return ''
+}
+
+/**
+ * Normalize URL to absolute URL
+ * If URL is already absolute (starts with http:// or https://), returns as-is
+ * If URL is relative, combines with base URL
+ */
+function normalizeUrl(url: string, baseUrl: string): string {
+  // Return absolute URLs as-is
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return url
+  }
+
+  // Normalize relative URLs
+  if (!baseUrl) {
+    // If no base URL available, return relative URL as-is
+    return url
+  }
+
+  try {
+    // Combine base URL with relative URL
+    return new URL(url, baseUrl).href
+  }
+  catch {
+    // If URL construction fails, return original URL
+    return url
+  }
+}
+
+/**
+ * Recursively normalize URLs in schema object
+ * Processes 'url', 'image', 'logo', and 'item' properties, including nested objects and arrays
+ */
+function normalizeSchemaUrls(obj: unknown, baseUrl: string): unknown {
+  if (!obj || typeof obj !== 'object') {
+    return obj
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(item => normalizeSchemaUrls(item, baseUrl))
+  }
+
+  const result: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(obj)) {
+    // Normalize 'url', 'image', 'logo', and 'item' properties
+    if ((key === 'url' || key === 'image' || key === 'logo' || key === 'item') && typeof value === 'string') {
+      result[key] = normalizeUrl(value, baseUrl)
+    }
+    // Recursively process nested objects
+    else if (value && typeof value === 'object') {
+      result[key] = normalizeSchemaUrls(value, baseUrl)
+    }
+    else {
+      result[key] = value
+    }
+  }
+
+  return result
+}
 
 /**
  * Helper function that recursively transforms object keys
@@ -196,8 +301,14 @@ export function useSchema(schema: Record<string, unknown> & {
   // Extract renderHtml, visuallyHidden options
   const { renderHtml = false, visuallyHidden = true, ...schemaData } = schema
 
+  // Get base URL for URL normalization
+  const baseUrl = getBaseUrl()
+
+  // Normalize URLs in schema data (before key transformation)
+  const normalizedSchemaData = normalizeSchemaUrls(schemaData, baseUrl) as Record<string, unknown>
+
   // Convert context, type to @context, @type
-  const transformedSchema = transformSchemaKeys(schemaData)
+  const transformedSchema = transformSchemaKeys(normalizedSchemaData)
 
   // Add default value if @context is missing
   const schemaWithContext = {


### PR DESCRIPTION
v1.2.6
feat: normalize `logo` and `item` properties in URL normalization

- Add `logo` and `item` to URL normalization in useSchema() and useSchemaFaq()
- Update documentation to reflect support for all URL properties
- Improve examples with mixed relative/absolute URLs for better demonstration

Fixes issue where ItemList item properties and logo properties were not
being normalized to absolute URLs as required by Schema.org standards.